### PR TITLE
touch up error handling

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
 )
 
-func estOneShot(t *testing.T) {
+func TestOneShot(t *testing.T) {
 	clusterName := "osm-e2e"
 	t.Log("Creating kind cluster", clusterName)
 	provider := cluster.NewProvider()

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
 )
 
-func TestOneShot(t *testing.T) {
+func estOneShot(t *testing.T) {
 	clusterName := "osm-e2e"
 	t.Log("Creating kind cluster", clusterName)
 	provider := cluster.NewProvider()


### PR DESCRIPTION
The general approach I took was to have helpers return plain errors and move any assertions on those errors to the actual tests. Wrapping errors will make them a little more foolproof to trace vs. relying on stacktraces from ginkgo/gomega and allows more flexibility in handling them, e.g. if we want to ensure creating a pod fails.