### PR TITLE
Add e2e test with Vault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ kind-reset:
 
 .PHONY: test-e2e
 test-e2e: docker-build-osm-controller docker-build-init build-osm
-	go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -containerRegistry $(CTR_REGISTRY) -osmImageTag $(CTR_TAG) -kindCluster
+	go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -ctrRegistry $(CTR_REGISTRY) -osmImageTag $(CTR_TAG) -kindCluster
 
 .env:
 	cp .env.example .env

--- a/go.sum
+++ b/go.sum
@@ -1296,8 +1296,6 @@ k8s.io/apimachinery v0.18.0/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftc
 k8s.io/apimachinery v0.18.5/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
 k8s.io/apimachinery v0.18.8 h1:jimPrycCqgx2QPearX3to1JePz7wSbVLq+7PdBTTwQ0=
 k8s.io/apimachinery v0.18.8/go.mod h1:6sQd+iHEqmOtALqOFjSWp2KZ9F0wlU/nWm0ZgsYWMig=
-k8s.io/apimachinery v0.19.1 h1:cwsxZazM/LA9aUsBaL4bRS5ygoM6bYp8dFk22DSYQa4=
-k8s.io/apimachinery v0.19.2 h1:5Gy9vQpAGTKHPVOh5c4plE274X8D/6cuEiTO2zve7tc=
 k8s.io/apiserver v0.18.0/go.mod h1:3S2O6FeBBd6XTo0njUrLxiqk8GNy6wWOftjhJcXYnjw=
 k8s.io/apiserver v0.18.5/go.mod h1:+1XgOMq7YJ3OyqPNSJ54EveHwCoBWcJT9CaPycYI5ps=
 k8s.io/cli-runtime v0.18.0 h1:jG8XpSqQ5TrV0N+EZ3PFz6+gqlCk71dkggWCCq9Mq34=

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -1,0 +1,110 @@
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Simple Client-Server pod test using Vault", func() {
+	Context("SimpleClientServer", func() {
+		sourceNs := "client"
+		destNs := "server"
+		var ns []string = []string{sourceNs, destNs}
+
+		It("Tests HTTP traffic for a simple client-server pod deployment", func() {
+			// Install OSM
+			installOpts := td.GetTestInstallOpts()
+			installOpts.certManager = "vault"
+			Expect(td.InstallOSM(installOpts)).To(Succeed())
+			Expect(td.WaitForPodsRunningReady(td.osmMeshName, 60*time.Second, 1)).To(Succeed())
+
+			// Create Test NS
+			for _, n := range ns {
+				Expect(td.CreateNs(n, nil)).To(Succeed())
+			}
+
+			// Get simple pod definitions for the HTTP server
+			svcAccDef, podDef, svcDef := td.SimplePodApp(
+				SimplePodAppDef{
+					name:      "server",
+					namespace: destNs,
+					image:     "kennethreitz/httpbin",
+				})
+
+			_, err := td.CreateServiceAccount(destNs, &svcAccDef)
+			Expect(err).NotTo(HaveOccurred())
+			dstPod, err := td.CreatePod(destNs, podDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = td.CreateService(destNs, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Expect it to be up and running in it's receiver namespace
+			Expect(td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
+
+			// Get simple Pod definitions for the client
+			svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
+				name:      "client",
+				namespace: sourceNs,
+				command:   []string{"/bin/bash", "-c", "--"},
+				args:      []string{"while true; do sleep 30; done;"},
+				image:     "songrgg/alpine-debug",
+			})
+
+			_, err = td.CreateServiceAccount(sourceNs, &svcAccDef)
+			Expect(err).NotTo(HaveOccurred())
+			srcPod, err := td.CreatePod(sourceNs, podDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = td.CreateService(sourceNs, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Expect it to be up and running in it's receiver namespace
+			Expect(td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
+
+			// Deploy allow rule client->server
+			httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+				SimpleAllowPolicy{
+					RouteGroupName:    "routes",
+					TrafficTargetName: "test-target",
+
+					SourceNamespace:      sourceNs,
+					SourceSVCAccountName: "client",
+
+					DestinationNamespace:      destNs,
+					DestinationSvcAccountName: "server",
+				})
+
+			// Configs have to be put into a monitored NS, and osm-system can't be by cli
+			_, err = td.CreateHTTPRouteGroup(sourceNs, httpRG)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = td.CreateTrafficTarget(sourceNs, trafficTarget)
+			Expect(err).NotTo(HaveOccurred())
+
+			// All ready. Expect client to reach server
+			// Need to get the pod though.
+			cond := WaitForRepeatedSuccess(func() bool {
+				statusCode, _, err :=
+					td.HTTPRequest(HTTPRequestDef{
+						SourceNs:        srcPod.Namespace,
+						SourcePod:       srcPod.Name,
+						SourceContainer: "client", // We can do better
+
+						Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+
+						HTTPUrl: "/",
+						Port:    80,
+					})
+
+				if err != nil || statusCode != 200 {
+					td.T.Logf("> REST req failed (status: %d) %v", statusCode, err)
+					return false
+				}
+				td.T.Logf("> REST req succeeded: %d", statusCode)
+				return true
+			}, 5, 60*time.Second)
+			Expect(cond).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
This PR adds a simple e2e test using HashiCorp Vault and adds install parameters for it.

@eduser25 Can you double check that I rebased this right? Mostly to make sure the container registry secret stuff still works.