### PR TITLE
Wrapping up second test and async HTTP helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,13 @@ require (
 	github.com/Azure/go-autorest/autorest v0.10.0
 	github.com/Azure/go-autorest/autorest/azure/auth v0.1.0
 	github.com/Azure/go-autorest/autorest/to v0.3.0
+	github.com/ahmetalpbalkan/go-cursor v0.0.0-20131010032410-8136607ea412
 	github.com/axw/gocov v1.0.0
 	github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354 // indirect
 	github.com/deckarep/golang-set v1.7.1
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce
 	github.com/envoyproxy/go-control-plane v0.9.6
+	github.com/fatih/color v1.9.0
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.4.2
 	github.com/golangci/golangci-lint v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/Venafi/vcert v0.0.0-20200310111556-eba67a23943f/go.mod h1:9EegQjmRoMqVT/ydgd54mJj5rTd7ym0qMgEfhnPsce0=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/ahmetalpbalkan/go-cursor v0.0.0-20131010032410-8136607ea412 h1:vOVO0ypMfTt6tZacyI0kp+iCZb1XSNiYDqnzBWYgfe4=
+github.com/ahmetalpbalkan/go-cursor v0.0.0-20131010032410-8136607ea412/go.mod h1:AI9hp1tkp10pAlK5TCwL+7yWbRgtDm9jhToq6qij2xs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alessio/shellescape v1.2.2 h1:8LnL+ncxhWT2TR00dfJRT25JWWrhkMZXneHVWnetDZg=

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -590,6 +590,7 @@ func (td *OsmTestData) WaitForPodsRunningReady(ns string, timeout time.Duration,
 				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
 					nReadyPods++
 					if nReadyPods == nExpectedRunningPods {
+						td.T.Logf("Finished waiting for NS [%s].", ns)
 						return nil
 					}
 				}

--- a/tests/e2e/common_traffic.go
+++ b/tests/e2e/common_traffic.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/fatih/color"
 )
 
 const (
@@ -24,34 +30,53 @@ type HTTPRequestDef struct {
 	Port    int
 }
 
+// HTTPRequestResult represents results of an HTTPRequest call
+type HTTPRequestResult struct {
+	StatusCode int
+	Headers    map[string]string
+	Err        error
+}
+
 // HTTPRequest runs a basic HTTP resquest from the source ns/pod/container to the a given host destination
 // Returns Status code, map with HTTP headers and error if any
-func (td *OsmTestData) HTTPRequest(ht HTTPRequestDef) (int, map[string]string, error) {
+func (td *OsmTestData) HTTPRequest(ht HTTPRequestDef) HTTPRequestResult {
 	// -s silent progress, -o output to devnull, '-D -' dump headers to "-" (stdout), -i Status code
 	// -I skip body download, '-w StatusCode:%{http_code}' prints Status code label-like for easy parsing
 	command := fmt.Sprintf("/usr/bin/curl -s -o /dev/null -D - -I -w %s:%%{http_code} http://%s:%d%s", StatusCodeWord, ht.Destination, ht.Port, ht.HTTPUrl)
 
-	td.T.Logf("- (Curl) HTTP GET %s/%s[%s] -> http://%s:%d%s", ht.SourceNs, ht.SourcePod, ht.SourceContainer, ht.Destination, ht.Port, ht.HTTPUrl)
+	//td.T.Logf("- (Curl) HTTP GET %s/%s[%s] -> http://%s:%d%s", ht.SourceNs, ht.SourcePod, ht.SourceContainer, ht.Destination, ht.Port, ht.HTTPUrl)
 	stdout, stderr, err := td.RunRemote(ht.SourceNs, ht.SourcePod, ht.SourceContainer, command)
 	if err != nil {
-		// Error codes from the execution will come in err
-		return 0, nil, fmt.Errorf("Remote exec err: %v | stderr: %s", err, stderr)
+		// Error codes from the execution come through err
+		// Curl 'Connection refused' err code = 7
+		return HTTPRequestResult{
+			0,
+			nil,
+			fmt.Errorf("Remote exec err: %v | stderr: %s", err, stderr),
+		}
 	}
 	if len(stderr) > 0 {
-		// no error from execution and proper exit code, but we got some stderr
+		// no error from execution and proper exit code, we got some stderr though
 		td.T.Logf("[warn] Stderr: %v", stderr)
 	}
 
 	// Expecting predictable output at this point
 	curlMappedReturn := mapCurlOuput(stdout)
-
 	statusCode, err := strconv.Atoi(curlMappedReturn[StatusCodeWord])
 	if err != nil {
-		return 0, nil, fmt.Errorf("Could not read status code as integer: %v", err)
+		return HTTPRequestResult{
+			0,
+			nil,
+			fmt.Errorf("Could not read status code as integer: %v", err),
+		}
 	}
 	delete(curlMappedReturn, StatusCodeWord)
 
-	return statusCode, curlMappedReturn, nil
+	return HTTPRequestResult{
+		statusCode,
+		curlMappedReturn,
+		nil,
+	}
 }
 
 // MapCurlOuput maps predictable stdout from our specific curl, which will
@@ -73,4 +98,87 @@ func mapCurlOuput(curlOut string) map[string]string {
 		ret[strings.TrimSpace(splitResult[0])] = strings.TrimSpace(splitResult[1])
 	}
 	return ret
+}
+
+// HTTPAsyncResults are a storage type for async results
+type HTTPAsyncResults struct {
+	mux        *sync.Mutex // Requied to read results by the caller, as they can updating
+	lastResult HTTPRequestResult
+}
+
+// NewHTTPAsyncResults returns a properly initialized async results instance
+func NewHTTPAsyncResults() *HTTPAsyncResults {
+	return &HTTPAsyncResults{
+		mux: &sync.Mutex{},
+		lastResult: HTTPRequestResult{
+			Headers: map[string]string{},
+		},
+	}
+}
+
+// Convenience function
+func (res HTTPAsyncResults) withLock(f func()) {
+	res.mux.Lock()
+	defer res.mux.Unlock()
+	f()
+}
+
+// HTTPAsync is the context fed to a HTTP async thread to run HTTP queries.
+// Stores Request definition, and pointers to results, stop and wait structures.
+// Pointers are used to signal the fact that the calling application might
+type HTTPAsync struct {
+	// Request
+	RequestData HTTPRequestDef
+
+	// Async results
+	ResponseDataStore *HTTPAsyncResults
+
+	// Stop signaling
+	StopSignal *bool
+	WaitGroup  *sync.WaitGroup
+
+	// Time sleep observed between requests
+	SleepTime time.Duration
+}
+
+// AsynchronousHTTPRunner is a template function which will run HTTP request, and update results at a regular interval.
+// Takes a context to store and synchronize with the calling thread
+func (td *OsmTestData) AsynchronousHTTPRunner(context HTTPAsync) {
+	context.WaitGroup.Add(1)
+	defer context.WaitGroup.Done()
+
+	for !*context.StopSignal {
+		result := td.HTTPRequest(context.RequestData)
+
+		context.ResponseDataStore.withLock(func() {
+			context.ResponseDataStore.lastResult = result
+		})
+
+		time.Sleep(context.SleepTime)
+	}
+}
+
+// PrettyPrintHTTPResults prints a line of results. Takes Title/App/NS name, list of pod names and list of results
+func (td *OsmTestData) PrettyPrintHTTPResults(appName string, podNames []string, asyncRes []*HTTPAsyncResults) {
+	Expect(len(podNames)).To(Equal(len(asyncRes)))
+
+	strLine := fmt.Sprintf("%s - ", color.CyanString(appName))
+	for idx := range podNames {
+		strLine += fmt.Sprintf("%s: %s -", podNames[idx], getColoredStatusCode(asyncRes[idx]))
+	}
+	td.T.Log(strLine)
+}
+
+func getColoredStatusCode(res *HTTPAsyncResults) string {
+	var coloredStatus string
+	res.withLock(func() {
+		if res.lastResult.Err != nil {
+			coloredStatus = color.RedString("ERR")
+		} else if res.lastResult.StatusCode != 200 {
+			coloredStatus = color.YellowString("%d ", res.lastResult.StatusCode)
+		} else {
+			coloredStatus = color.HiGreenString("%d ", res.lastResult.StatusCode)
+		}
+	})
+	return coloredStatus
 }

--- a/tests/e2e/e2e_10svc_100pods_test.go
+++ b/tests/e2e/e2e_10svc_100pods_test.go
@@ -1,29 +1,43 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/ahmetalpbalkan/go-cursor"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Test 10(x10 pods) Clients -> 1(x10 pods) server", func() {
 	Context("DeploymentsClientServer", func() {
 		destApp := "server"
 		sourceAppBaseName := "client"
-		sourceApplications := []string{}
+		var sourceNamespaces []string = []string{} // for this test, (Service name == NS name == container name)
+		var podsPerNamespace map[string][]string = map[string][]string{}
 
-		// Total 100 pods
-		numberOfClientApps := 10
+		// Total (numberOfClientApps x replicaSetPerApp) pods
+		numberOfClientApps := 5
 		replicaSetPerApp := 10
 
+		// Used accross the test to wait for concurrent steps to finish
+		var wg sync.WaitGroup
+
 		for i := 0; i < numberOfClientApps; i++ {
-			sourceApplications = append(sourceApplications, fmt.Sprintf("%s%d", sourceAppBaseName, i))
+			sourceNamespaces = append(sourceNamespaces, fmt.Sprintf("%s%d", sourceAppBaseName, i))
 		}
 
 		It("Tests HTTP traffic for a simple client-server pod deployment", func() {
+			// For Cleanup only
+			td.Namespaces["server"] = true
+			for _, srcClient := range sourceNamespaces {
+				td.Namespaces[srcClient] = true
+			}
+
 			// Install OSM
 			Expect(td.InstallOSM(td.GetTestInstallOpts())).To(Succeed())
 			Expect(td.WaitForPodsRunningReady(td.osmMeshName, 60*time.Second, 1)).To(Succeed())
@@ -34,13 +48,10 @@ var _ = Describe("Test 10(x10 pods) Clients -> 1(x10 pods) server", func() {
 			Expect(td.AddNsToMesh(true, destApp)).To(Succeed())
 
 			// Client Applications
-			for _, srcClient := range sourceApplications {
+			for _, srcClient := range sourceNamespaces {
 				Expect(td.CreateNs(srcClient, nil)).To(Succeed())
 				Expect(td.AddNsToMesh(true, srcClient)).To(Succeed())
 			}
-
-			// To wait for all
-			var wg sync.WaitGroup
 
 			// Get simple pod definitions for the HTTP server
 			svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
@@ -64,7 +75,7 @@ var _ = Describe("Test 10(x10 pods) Clients -> 1(x10 pods) server", func() {
 				Expect(td.WaitForPodsRunningReady(destApp, 200*time.Second, replicaSetPerApp)).To(Succeed())
 			}(&wg, destApp)
 
-			for _, srcClient := range sourceApplications {
+			for _, srcClient := range sourceNamespaces {
 				svcAccDef, deploymentDef, svcDef = td.SimpleDeploymentApp(
 					SimpleDeploymentAppDef{
 						name:         srcClient,
@@ -87,8 +98,118 @@ var _ = Describe("Test 10(x10 pods) Clients -> 1(x10 pods) server", func() {
 					Expect(td.WaitForPodsRunningReady(srcClient, 200*time.Second, replicaSetPerApp)).To(Succeed())
 				}(&wg, srcClient)
 			}
-
 			wg.Wait()
+
+			// Create traffic rules
+			// Deploy allow rules (10x)clients -> server
+			for _, srcClient := range sourceNamespaces {
+				httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+					SimpleAllowPolicy{
+						RouteGroupName:    srcClient,
+						TrafficTargetName: srcClient,
+
+						SourceNamespace:      srcClient,
+						SourceSVCAccountName: srcClient,
+
+						DestinationNamespace:      destApp,
+						DestinationSvcAccountName: destApp,
+					})
+
+				// Configs have to be put into a monitored NS, and osm-system can't be by cli
+				_, err = td.CreateHTTPRouteGroup(srcClient, httpRG)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// Get Deterministic list of pods per source application
+			// Walking maps is NOT deterministic in golang, this causes scrambled output later when walking map ranges repeatedly
+			for _, ns := range sourceNamespaces {
+				// Get pods for every service (assuming every service is enclosed in a namespace, we can get all pods for an NS)
+				pods, err := td.Client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+				Expect(err).To(BeNil())
+
+				for _, pod := range pods.Items {
+					_, found := podsPerNamespace[ns]
+					if !found {
+						podsPerNamespace[ns] = []string{}
+					}
+					podsPerNamespace[ns] = append(podsPerNamespace[ns], pod.Name)
+				}
+			}
+
+			// Map[ns][pod] -> HTTPResults
+			var results map[string]map[string]*HTTPAsyncResults = make(map[string]map[string]*HTTPAsyncResults)
+			// synchronization artifacts. We will reuse the global waitgroup
+			var stop bool = false
+
+			// Start HTTP async threads
+			for _, ns := range sourceNamespaces {
+				for _, pod := range podsPerNamespace[ns] {
+					// Create a Result
+					_, ok := results[ns]
+					if !ok {
+						results[ns] = make(map[string]*HTTPAsyncResults)
+					}
+					results[ns][pod] = NewHTTPAsyncResults()
+
+					go td.AsynchronousHTTPRunner(
+						HTTPAsync{
+							RequestData: HTTPRequestDef{
+								SourceNs:        ns,
+								SourcePod:       pod,
+								SourceContainer: ns, // container_name == NS for this test
+
+								Destination: fmt.Sprintf("%s.%s", destApp, destApp),
+
+								HTTPUrl: "/",
+								Port:    80,
+							},
+							ResponseDataStore: results[ns][pod],
+							StopSignal:        &stop,
+							WaitGroup:         &wg,
+							SleepTime:         1 * time.Second,
+						},
+					)
+				}
+			}
+
+			// Inspect results and wait for success/failure
+			success := WaitForRepeatedSuccess(func() bool {
+				var overallSuccess bool = true
+
+				for _, ns := range sourceNamespaces {
+					podNames := []string{}
+					podResultsToPrint := []*HTTPAsyncResults{}
+
+					for _, pod := range podsPerNamespace[ns] {
+						podRes := results[ns][pod]
+
+						podResultsToPrint = append(podResultsToPrint, podRes)
+						podNames = append(podNames, pod)
+
+						podRes.withLock(func() {
+							if podRes.lastResult.Err != nil || podRes.lastResult.StatusCode != 200 {
+								overallSuccess = false
+							}
+						})
+					}
+					td.PrettyPrintHTTPResults(ns, podNames, podResultsToPrint)
+				}
+				// Meaningful only on shell
+				td.T.Log(cursor.MoveUp(len(sourceNamespaces) + 1))
+
+				return overallSuccess
+			}, 5, 150*time.Second)
+
+			// Meaningful only on shell
+			td.T.Log(cursor.MoveDown(len(sourceNamespaces) + 1))
+
+			// Stop all async threads
+			stop = true
+			wg.Wait()
+
+			Expect(success).To(BeTrue())
 		})
 	})
 })

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Simple Client-Server pod test using Vault", func() {
 			// All ready. Expect client to reach server
 			// Need to get the pod though.
 			cond := WaitForRepeatedSuccess(func() bool {
-				statusCode, _, err :=
+				result :=
 					td.HTTPRequest(HTTPRequestDef{
 						SourceNs:        srcPod.Namespace,
 						SourcePod:       srcPod.Name,
@@ -97,11 +97,11 @@ var _ = Describe("Simple Client-Server pod test using Vault", func() {
 						Port:    80,
 					})
 
-				if err != nil || statusCode != 200 {
-					td.T.Logf("> REST req failed (status: %d) %v", statusCode, err)
+				if result.Err != nil || result.StatusCode != 200 {
+					td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
 					return false
 				}
-				td.T.Logf("> REST req succeeded: %d", statusCode)
+				td.T.Logf("> REST req succeeded: %d", result.StatusCode)
 				return true
 			}, 5, 60*time.Second)
 			Expect(cond).To(BeTrue())

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Simple Client-Server pod test", func() {
 			// All ready. Expect client to reach server
 			// Need to get the pod though.
 			cond := WaitForRepeatedSuccess(func() bool {
-				statusCode, _, err :=
+				result :=
 					td.HTTPRequest(HTTPRequestDef{
 						SourceNs:        srcPod.Namespace,
 						SourcePod:       srcPod.Name,
@@ -95,11 +95,11 @@ var _ = Describe("Simple Client-Server pod test", func() {
 						Port:    80,
 					})
 
-				if err != nil || statusCode != 200 {
-					td.T.Logf("> REST req failed (status: %d) %v", statusCode, err)
+				if result.Err != nil || result.StatusCode != 200 {
+					td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
 					return false
 				}
-				td.T.Logf("> REST req succeeded: %d", statusCode)
+				td.T.Logf("> REST req succeeded: %d", result.StatusCode)
 				return true
 			}, 5, 60*time.Second)
 			Expect(cond).To(BeTrue())


### PR DESCRIPTION
- Includes some helpers to create Async HTTP requests

We might add a more generic abstraction for further tests which
encompasses the HTTP request testing from multiple sources to one
destination. 
Seems a useful enough abstraction that might very well be
needed going forward.
